### PR TITLE
Add SingleBlameLine

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,14 @@ the plugin is exposed through the functions:
 
 EnableBlameLine, 
 DisableBlameLine, 
-ToggleBlameLine
+ToggleBlameLine,
+SingleBlameLine
 
 example:
 
-```
+```viml
 nmap <silent> <leader>b :ToggleBlameLine<CR>
+nmap <silent> <leader>s :SingleBlameLine<CR> " Show blame for a single line.
 ```
 
 #### Options

--- a/plugin/blameline.vim
+++ b/plugin/blameline.vim
@@ -13,3 +13,4 @@ augroup END
 command! ToggleBlameLine :call b:ToggleBlameLine()
 command! EnableBlameLine :call blameline#EnableBlameLine()
 command! DisableBlameLine :call blameline#DisableBlameLine()
+command! SingleBlameLine :call blameline#SingleBlameLine()


### PR DESCRIPTION
Added a command to show the blame for a single line. The blame text is removed when the cursor is moved to a different line.

I could envisage an alternate command that does not clear the blame annotation on cursor move. Plus a command to clear all blames.