### PR TITLE
Add options for virtual text highlight and prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # nvim-blame-line
+
 A small plugin that uses neovims virtual text to print git blame info at the end of the current line.
 
 Also supports showing blame below the current window, for normal vim users.
@@ -6,34 +7,41 @@ Also supports showing blame below the current window, for normal vim users.
 nvim-blame-line prints author, date and summary of the commit belonging to the line underneath the cursor.
 Just like a real IDE!
 
-### Installation:
+## Installation
+
 Use a plugin manager like [vim-plug](https://github.com/junegunn/vim-plug)
 
 ```
 Plug 'tveskag/nvim-blame-line'
 ```
 
-### Usage:
+## Usage
 
-![example gif](https://github.com/tveskag/nvim-blame-line/blob/master/img/example.gif "Example gif")
+![Example gif](https://github.com/tveskag/nvim-blame-line/blob/master/img/example.gif "Example gif")
 
-#### Functions
-the plugin is exposed through the functions:
+### Commands
 
-EnableBlameLine, 
-DisableBlameLine, 
-ToggleBlameLine
+The plugin is exposed through these commands:
 
-example:
+- `EnableBlameLine`
+- `DisableBlameLine`
+- `ToggleBlameLine`
 
+Example mapping:
+
+```vim
+nnoremap <silent> <leader>b :ToggleBlameLine<CR>
 ```
-nmap <silent> <leader>b :ToggleBlameLine<CR>
-```
 
-#### Options
+### Options
  
-To show blame info below the current window instead, put this in your vimrc:
-
-```
+```vim
+" Show blame info below the statusline instead of using virtual text
 let g:blameLineUseVirtualText = 0
+
+" Specify the highlight group used for the virtual text ('Comment' by default)
+let g:blameLineVirtualTextHighlight = 'Question'
+
+" Add a prefix to the virtual text (empty by default)
+let g:blameLineVirtualTextPrefix = '// '
 ```

--- a/autoload/blameline.vim
+++ b/autoload/blameline.vim
@@ -1,6 +1,6 @@
 function! s:nvimAnnotate(comment, bufN, lineN)
     call nvim_buf_clear_namespace(a:bufN, s:ns_id, 0, -1)
-    call nvim_buf_set_virtual_text(a:bufN, s:ns_id, a:lineN - 1, [[a:comment, "Comment"]], {})
+    call nvim_buf_set_virtual_text(a:bufN, s:ns_id, a:lineN - 1, [[a:comment, g:blameLineVirtualTextHighlight]], {})
 endfunction
 
 function! s:vimEcho(comment, ...)

--- a/autoload/blameline.vim
+++ b/autoload/blameline.vim
@@ -34,7 +34,7 @@ function! s:getAnnotation(bufN, lineN)
         call s:vimEcho(l:annotation[-1])
         return ''
     endif
-    return l:annotation[0]
+    return g:blameLineVirtualTextPrefix . l:annotation[0]
 endfunction
 
 function! s:createCursorHandler(bufN)

--- a/plugin/blameline.vim
+++ b/plugin/blameline.vim
@@ -5,6 +5,7 @@ let g:blameline_loaded = 1
 
 let g:blameLineUseVirtualText = get(g:, 'blameLineUseVirtualText', 1)
 let g:blameLineVirtualTextHighlight = get(g:, 'blameLineVirtualTextHighlight', 'Comment')
+let g:blameLineVirtualTextPrefix = get(g:, 'blameLineVirtualTextPrefix', '')
 
 augroup enableBlameLine
     autocmd!

--- a/plugin/blameline.vim
+++ b/plugin/blameline.vim
@@ -4,6 +4,7 @@ endif
 let g:blameline_loaded = 1
 
 let g:blameLineUseVirtualText = get(g:, 'blameLineUseVirtualText', 1)
+let g:blameLineVirtualTextHighlight = get(g:, 'blameLineVirtualTextHighlight', 'Comment')
 
 augroup enableBlameLine
     autocmd!


### PR DESCRIPTION
Implements https://github.com/tveskag/nvim-blame-line/issues/6, and also adds an option to add a prefix to the virtual text.