### PR TITLE
Fix when `git rev-parse --git-dir` returns relative path

### DIFF
--- a/autoload/blameline.vim
+++ b/autoload/blameline.vim
@@ -64,8 +64,11 @@ function! blameline#InitBlameLine()
             let b:ToggleBlameLine = function('s:vimEcho', [b:BlameLineGitdir])
             return
         endif
+        if b:BlameLineGitdir[0] !=# '/'
+            let b:BlameLineGitdir = expand('%:p:h').'/'.b:BlameLineGitdir
+        endif
 
-        let l:rel_to_git_parent = substitute(expand('%:p'), fnamemodify(b:BlameLineGitdir, ':h').'/', '', '')
+        let l:rel_to_git_parent = substitute(expand('%:p'), escape(fnamemodify(b:BlameLineGitdir, ':h').'/', '.'), '', '')
         let l:fileExists = systemlist('cd '.expand('%:p:h').'; git cat-file -e HEAD:'.l:rel_to_git_parent)
         if v:shell_error > 0
             let b:ToggleBlameLine = function('s:vimEcho', l:fileExists)


### PR DESCRIPTION
From `man git-rev-parse`:

``` man
--git-dir
    Show $GIT_DIR if defined. Otherwise show the path to the .git directory. The path shown, when relative, is relative to the current working directory.

    If $GIT_DIR is not defined and the current directory is not detected to lie in a Git repository or work tree print a message to stderr and exit with
    nonzero status.
```

For example, `git rev-parse --git-dir` returns `.git` if it's the root of a git repository.

Also `.` in the pattern of `substitute()` matches to every character, so it should be escaped.