### PR TITLE
change VirtualTextPrefix to VirtualTextFormat

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ let g:blameLineUseVirtualText = 0
 " Specify the highlight group used for the virtual text ('Comment' by default)
 let g:blameLineVirtualTextHighlight = 'Question'
 
-" Add a prefix to the virtual text (empty by default)
-let g:blameLineVirtualTextPrefix = '// '
+" Change format of virtual text ('%s' by default)
+let g:blameLineVirtualTextFormat = '/* %s */'
 
 " Customize format for git blame (Default format: '%an | %ar | %s')
 let g:blameLineGitFormat = '%an - %s'

--- a/plugin/blameline.vim
+++ b/plugin/blameline.vim
@@ -6,7 +6,7 @@ let g:blameLine_loaded = 1
 let g:blameLineGitFormat = get(g:, 'blameLineGitFormat', '%an | %ar | %s')
 let g:blameLineUseVirtualText = get(g:, 'blameLineUseVirtualText', 1)
 let g:blameLineVirtualTextHighlight = get(g:, 'blameLineVirtualTextHighlight', 'Comment')
-let g:blameLineVirtualTextPrefix = get(g:, 'blameLineVirtualTextPrefix', '')
+let g:blameLineVirtualTextFormat = get(g:, 'blameLineVirtualTextFormat', '%s')
 let g:blameLineVerbose = get(g:, 'blameLineVerbose', 0)
 
 function s:createError(error)
@@ -51,7 +51,7 @@ function! s:getAnnotation(bufN, lineN, gitdir)
     if v:shell_error > 0
         let b:onCursorMoved = s:createError(l:annotation)
     endif
-    return g:blameLineVirtualTextPrefix . l:annotation[0]
+    return printf(g:blameLineVirtualTextFormat, l:annotation[0])
 endfunction
 
 function! s:createCursorHandler(bufN, gitdir, anno)


### PR DESCRIPTION
**for more flexibility purpose**

i am using it for dynamically use current syntax comment style:
```vim
	autocmd VimEnter *
		\ let g:blameLineUseVirtualTextFormat
		\   = substitute(
		\       substitute(
		\         substitute(&commentstring, '^$', '%s', ''),
		\         '\S\zs%s',' %s', ''
		\       ),
		\       '%s\ze\S', '%s ', ''
		\     )
```