### PR TITLE
Allow user change message when content is not yet committed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,7 @@ let g:blameLineVirtualTextFormat = '/* %s */'
 " Customize format for git blame (Default format: '%an | %ar | %s')
 let g:blameLineGitFormat = '%an - %s'
 " Refer to 'git-show --format=' man pages for format options)
+
+" Change message when content is not committed
+let g:blameLineMessageWhenNotYetCommited = ''
 ```

--- a/plugin/blameline.vim
+++ b/plugin/blameline.vim
@@ -8,6 +8,7 @@ let g:blameLineUseVirtualText = get(g:, 'blameLineUseVirtualText', 1)
 let g:blameLineVirtualTextHighlight = get(g:, 'blameLineVirtualTextHighlight', 'Comment')
 let g:blameLineVirtualTextFormat = get(g:, 'blameLineVirtualTextFormat', '%s')
 let g:blameLineVerbose = get(g:, 'blameLineVerbose', 0)
+let g:blameLineMessageWhenNotYetCommited = get(g:, 'blameLineMessageWhenNotYetCommited', 'Not yet committed')
 
 function s:createError(error)
     return g:blameLineVerbose ? {-> s:vimEcho(a:error) && s:DisableBlameLine()} : {-> s:DisableBlameLine()}
@@ -44,7 +45,8 @@ function! s:getAnnotation(bufN, lineN, gitdir)
     let l:commit = strpart(l:blame[0], 0, 40)
     let l:format = g:blameLineGitFormat
     if l:commit ==# '0000000000000000000000000000000000000000'
-        let l:annotation = ['Not yet committed']
+        " show nothing when this line is not yet committed.
+        let l:annotation = [g:blameLineMessageWhenNotYetCommited]
     else
         let l:annotation = systemlist(l:gitcommand.' show '.l:commit.' --format="'.l:format.'"')
     endif


### PR DESCRIPTION
Hi tveskag,

Thanks for created this small but useful plugin.

I want to provide user a configuration which allow user change message when content is not committed rather than static code `Not yet committed`.

I set the default value of this configuration to `Not yet committed` so that other user can use it as usual.