### PR TITLE
discard diff when looking up commit info

### DIFF
--- a/plugin/blameline.vim
+++ b/plugin/blameline.vim
@@ -48,7 +48,7 @@ function! s:getAnnotation(bufN, lineN, gitdir)
         " show nothing when this line is not yet committed.
         let l:annotation = [g:blameLineMessageWhenNotYetCommited]
     else
-        let l:annotation = systemlist(l:gitcommand.' show '.l:commit.' --format="'.l:format.'"')
+        let l:annotation = systemlist(l:gitcommand.' show -s '.l:commit.' --format="'.l:format.'"')
     endif
     if v:shell_error > 0
         let b:onCursorMoved = s:createError(l:annotation)


### PR DESCRIPTION
When looking for a commit containing the line use the `-s` flag to reduce the amount of data git has to return and the macro has to process. this can speed-up blameline on certain large repos, especially those that contain commits with very large diff's.
 